### PR TITLE
Ignore package-lock.json for vercel. Throws 401 npm authentication error

### DIFF
--- a/dashboard/.vercelignore
+++ b/dashboard/.vercelignore
@@ -1,0 +1,1 @@
+package-lock.json


### PR DESCRIPTION
Ignore package-lock.json for vercel. Throws 401 npm authentication error
Even had correct repository set in .npmrc